### PR TITLE
Changing any + is.na to anyNA

### DIFF
--- a/R/get_interval.R
+++ b/R/get_interval.R
@@ -25,7 +25,7 @@ get_interval <- function(x) {
 }
 
 stop_on_NA <- function(x) {
-  if(any(is.na(x))) {
+  if(anyNA(x)) {
     stop("interval cannot be determined when x contains NAs")
   }
 }

--- a/R/pad.R
+++ b/R/pad.R
@@ -421,7 +421,7 @@ get_dt_var_and_name <- function(x, by) {
 check_for_NA_pad <- function(x, dt_var, dt_var_name) {
   x_no_NA <- x
   x_NA <- NULL
-  if(any(is.na(dt_var))) {
+  if(anyNA(dt_var)) {
     x_no_NA <- x[!is.na(dt_var), ]
     x_NA <- x[is.na(dt_var), ]
     warn_mess <- sprintf(


### PR DESCRIPTION
It's a small change, but [anyNA is a more efficient way of searching to anyNAs, especially for atomic vectors.](https://stat.ethz.ch/R-manual/R-devel/library/base/html/NA.html)