### PR TITLE
Performance improvement for pad()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,8 @@ Depends:
 Imports:
     Rcpp,
     dplyr (>= 1.0.0),
+    tidyr,
+    purrr,
     lubridate,
     rlang
 Suggests:
@@ -23,7 +25,6 @@ Suggests:
     knitr,
     rmarkdown,
     lazyeval,
-    tidyr,
     data.table
 RoxygenNote: 7.1.0
 LinkingTo: Rcpp

--- a/R/pad.R
+++ b/R/pad.R
@@ -283,37 +283,12 @@ check_invalid_start_and_end <- function(x) {
   return(x)
 }
 
-# id_vars is a data frame with one row containing the single value,
-# the column names are returned in the result
-# Worker of span_all_groups function
-# span_from_min_max_single <- function(start,
-#                                      end,
-#                                      interval,
-#                                      id_vars) {
-#   if (inherits(start, "POSIXt") & interval %in% c("day", "week")) {
-#     interval <- "DSTday"
-#   }
-#   ret <- data.frame(span = seq(start, end, by = interval))
-#   return(as.data.frame(cbind(ret, id_vars)))
-# }
-#
-# # x is the output of get_min_max
-# span_all_groups <- function(x, interval) {
-#   select_index <- which(!colnames(x) %in% c("mn", "mx"))
-#   id_vars <- split( dplyr::select(x, select_index), seq(nrow(x)))
-#   stop_int64(id_vars)
-#
-#   list_span <- mapply(span_from_min_max_single,
-#                       start = x$mn,
-#                       end   = x$mx,
-#                       interval = interval,
-#                       id_vars = id_vars,
-#                       SIMPLIFY = FALSE)
-#
-#   dplyr::bind_rows(list_span)
-# }
-
+# x is the output from get_min_max
 span_all_groups <- function(x, interval){
+  if (inherits(x$mn, "POSIXt") & interval %in% c("day","week")){
+    interval <- "DSTday"
+  }
+
   x <- x %>%
     dplyr::mutate(span = purrr::map2(.x = mn,.y = mx,.f = seq,by = interval)) %>%
     tidyr::unnest(cols = c(span)) %>%

--- a/R/pad.R
+++ b/R/pad.R
@@ -89,6 +89,9 @@
 #' pad(x, group = "id")
 #' # applying pad with do, interval is determined individualle for each group
 #' x %>% group_by(id) %>% do(pad(.))
+#' @import dplyr
+#' @importFrom tidyr unnest
+#' @importFrom purrr map2
 #' @export
 pad <- function(x,
                 interval  = NULL,
@@ -283,31 +286,42 @@ check_invalid_start_and_end <- function(x) {
 # id_vars is a data frame with one row containing the single value,
 # the column names are returned in the result
 # Worker of span_all_groups function
-span_from_min_max_single <- function(start,
-                                     end,
-                                     interval,
-                                     id_vars) {
-  if (inherits(start, "POSIXt") & interval %in% c("day", "week")) {
-    interval <- "DSTday"
-  }
-  ret <- data.frame(span = seq(start, end, by = interval))
-  return(as.data.frame(cbind(ret, id_vars)))
-}
+# span_from_min_max_single <- function(start,
+#                                      end,
+#                                      interval,
+#                                      id_vars) {
+#   if (inherits(start, "POSIXt") & interval %in% c("day", "week")) {
+#     interval <- "DSTday"
+#   }
+#   ret <- data.frame(span = seq(start, end, by = interval))
+#   return(as.data.frame(cbind(ret, id_vars)))
+# }
+#
+# # x is the output of get_min_max
+# span_all_groups <- function(x, interval) {
+#   select_index <- which(!colnames(x) %in% c("mn", "mx"))
+#   id_vars <- split( dplyr::select(x, select_index), seq(nrow(x)))
+#   stop_int64(id_vars)
+#
+#   list_span <- mapply(span_from_min_max_single,
+#                       start = x$mn,
+#                       end   = x$mx,
+#                       interval = interval,
+#                       id_vars = id_vars,
+#                       SIMPLIFY = FALSE)
+#
+#   dplyr::bind_rows(list_span)
+# }
 
-# x is the output of get_min_max
-span_all_groups <- function(x, interval) {
-  select_index <- which(!colnames(x) %in% c("mn", "mx"))
-  id_vars <- split( dplyr::select(x, select_index), seq(nrow(x)))
-  stop_int64(id_vars)
+span_all_groups <- function(x, interval){
+  x <- x %>%
+    dplyr::mutate(span = purrr::map2(.x = mn,.y = mx,.f = seq,by = interval)) %>%
+    tidyr::unnest(cols = c(span)) %>%
+    dplyr::select(-mn,-mx) %>%
+    dplyr::relocate(span,.before = everything()) %>%
+    as.data.frame()
 
-  list_span <- mapply(span_from_min_max_single,
-                      start = x$mn,
-                      end   = x$mx,
-                      interval = interval,
-                      id_vars = id_vars,
-                      SIMPLIFY = FALSE)
-
-  dplyr::bind_rows(list_span)
+  x
 }
 
 # currently int64 gives so much trouble, I chose to just break for now.

--- a/R/pad.R
+++ b/R/pad.R
@@ -300,6 +300,8 @@ span_all_groups <- function(x, interval){
 }
 
 # currently int64 gives so much trouble, I chose to just break for now.
+# this is no longer used in this faster version of span_all_groups; pretty
+# sure it was not checking correctly anyway
 stop_int64 <- function(id_var_df) {
   classes_id <- unlist(sapply(id_var_df, class))
   if ("integer64" %in% classes_id) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // round_down_core
 IntegerVector round_down_core(IntegerVector a, IntegerVector b);
 RcppExport SEXP _padr_round_down_core(SEXP aSEXP, SEXP bSEXP) {


### PR DESCRIPTION
I was profiling some code that calls `padr::pad()` and found that `span_all_groups()` was using a significant chunk of the total time. This proposed change converts `span_all_groups()` to use `purrr::map2` and `tidyr::unnest()` to accomplish the same thing. In my tests it is ~2x faster than the original `span_all_groups()` on my M1 Max Apple laptop and ~3x faster on the virtual Linux machine I use for work. It's a small absolute improvement on my Mac (<0.5sec) but a more noticeable improvement on my slower work Linux machine (~1.5sec), at least in my context, where I'm doing some data processing while loading a Shiny app.

A tradeoff is the additional imports of `purrr::map2` and `tidyr::unnest`. I noticed that padr seems to stick to base R as much as possible, so I'll understand if you're reluctant to add the additional dependencies. 

Unrelated, but I think the existing `stop_int64()` call isn't actually doing anything, since it's being called on the list output from `split()` and so it's looking at the classes of the individual list elements rather than the columns in the original data frame.

All existing tests in the package are passing with this change.